### PR TITLE
Enabled extended result codes.

### DIFF
--- a/src/sqlite/connection.cpp
+++ b/src/sqlite/connection.cpp
@@ -39,6 +39,7 @@ namespace sqlite{
     connection::connection(std::string const & db)
         : handle(0){
             open(db);
+            sqlite3_extended_result_codes(handle, 1);
     }
 
     connection::~connection(){


### PR DESCRIPTION
With the change to exceptions to make error codes accessible, it would be nice to have the extended error code available, so the caller gets as much information as possible.
