### PR TITLE
Add open_readonly mode to sqlite::open_mode for SQLITE_OPEN_READONLY

### DIFF
--- a/include/sqlite/connection.hpp
+++ b/include/sqlite/connection.hpp
@@ -37,6 +37,7 @@ struct sqlite3;
 
 namespace sqlite{
     enum class open_mode {
+        open_readonly,  ///!> Opens an existing database for reads only or fails
         open_existing,  ///!> Opens an existing database or fails
         open_or_create, ///!> Opens an existing database or creates it
         always_create   ///!> Deletes database if exists and recreates it
@@ -95,6 +96,7 @@ namespace sqlite{
         friend struct private_accessor;
     private:
         void open(std::string const & db);
+        void open(std::string const & db, bool readonly);
         void open(std::string const & db, sqlite::open_mode open_mode);
         void close();
         void access_check();


### PR DESCRIPTION
It may be useful to open some database in read-only mode.