### PR TITLE
Add support for SQLite backup API

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -8,6 +8,7 @@ lib_LTLIBRARIES = libvsqlitepp.la
 libvsqlitepp_la_CXXFLAGS = -I include $(AM_CXXFLAGS)
 libvsqlitepp_la_LDFLAGS = -Wl,--no-as-needed -lsqlite3 -lboost_system -lboost_filesystem -Wl,-soname -Wl,libvsqlitepp.so.3 -version-info 3:0:0 
 libvsqlitepp_la_SOURCES = \
+	src/sqlite/backup.cpp \
 	src/sqlite/command.cpp \
 	src/sqlite/connection.cpp \
 	src/sqlite/savepoint.cpp \

--- a/examples/sqlite_wrapper.cpp
+++ b/examples/sqlite_wrapper.cpp
@@ -29,6 +29,7 @@
  POSSIBILITY OF SUCH DAMAGE.
 
 ##############################################################################*/
+#include <sqlite/backup.hpp>
 #include <sqlite/connection.hpp>
 #include <sqlite/execute.hpp>
 #include <sqlite/query.hpp>
@@ -40,6 +41,8 @@ int main()
     try
     {
         sqlite::connection con("test.db");
+
+        sqlite::connection con_memory(":memory:");
 
         sqlite::execute(con,"Create Table IF NOT EXISTS test(id INTEGER PRIMARY KEY, name TEXT);",true);
 
@@ -65,6 +68,17 @@ int main()
         res->reset();
         while(res->next_row()) {
             std::cout << res->get_int(0) << "|" << res->get_string(1) << std::endl;
+        }
+
+        sqlite::backup backup_op(con_memory, con);
+        backup_op.step();
+        backup_op.finish();
+
+        sqlite::query q_memory(con_memory, "SELECT * FROM test;");
+
+        boost::shared_ptr<sqlite::result> res2 = q_memory.get_result();
+        while(res2->next_row()) {
+            std::cout << res2->get_int(0) << "|" << res2->get_string(1) << std::endl;
         }
 
         sqlite::execute(con,"DROP TABLE test;",true);

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -1,4 +1,5 @@
 nobase_include_HEADERS = \
+    sqlite/backup.hpp \
     sqlite/command.hpp \
     sqlite/connection.hpp \
     sqlite/database_exception.hpp \

--- a/include/sqlite/backup.hpp
+++ b/include/sqlite/backup.hpp
@@ -1,0 +1,22 @@
+#ifndef GUARD_SQLITE_BACKUP_HPP_INCLUDED
+#define GUARD_SQLITE_BACKUP_HPP_INCLUDED
+
+#include <boost/noncopyable.hpp>
+#include <sqlite/connection.hpp>
+
+struct sqlite3_backup;
+
+namespace sqlite {
+    struct backup: boost::noncopyable {
+        backup(connection& conn_to, connection& conn_from);
+        ~backup();
+        bool step(int nPage = -1);
+        void finish();
+    private:
+        sqlite3* get_to_handle() const;
+    private:
+        sqlite3_backup* m_pBackup;
+        connection& m_conn_to;
+    };
+}
+#endif // #ifndef GUARD_SQLITE_BACKUP_HPP_INCLUDED

--- a/include/sqlite/backup.hpp
+++ b/include/sqlite/backup.hpp
@@ -7,11 +7,37 @@
 struct sqlite3_backup;
 
 namespace sqlite {
+    /** \brief \a backup is a class for representing SQLite backup operations
+      * An object of this class is not copyable
+      */
     struct backup: boost::noncopyable {
+        /** \brief \a backup constructor
+          * \param conn_to takes a reference to the \a connection object
+          *        of the destination database
+          * \param conn_from takes a reference to the \a connection object
+          *        of the source database
+          */
         backup(connection& conn_to, connection& conn_from);
+
+        /** \brief \a backup destructor. The backup operation is automatically
+          *        finished after the object destructed.
+          */
         ~backup();
+
+
+        /** \brief Do a backup step
+          * \param nPage the number of pages to backup in this step. If a
+          *        negative integer is given, all pages are backuped. If this
+          *        parameter is omitted, -1 is used.
+          */
         bool step(int nPage = -1);
+
+        /** \brief Finish the backup operation
+          *        This is used for flushing current backup operation. After
+          *        this call, the backup object should not be used anymore.
+          */
         void finish();
+
     private:
         sqlite3* get_to_handle() const;
     private:

--- a/src/sqlite/backup.cpp
+++ b/src/sqlite/backup.cpp
@@ -1,0 +1,59 @@
+#include <sqlite/backup.hpp>
+#include <sqlite/connection.hpp>
+#include <sqlite/private/private_accessor.hpp>
+#include <sqlite/database_exception.hpp>
+#include <sqlite3.h>
+
+namespace sqlite {
+    backup::backup(connection& conn_to, connection& conn_from)
+        : m_pBackup(NULL), m_conn_to(conn_to) {
+        private_accessor::acccess_check(conn_to);
+        private_accessor::acccess_check(conn_from);
+
+        m_pBackup = sqlite3_backup_init(get_to_handle(), "main",
+            private_accessor::get_handle(conn_from), "main");
+        if(!m_pBackup) {
+            throw database_exception_code(sqlite3_errmsg(get_to_handle()),
+                sqlite3_errcode(get_to_handle()));
+        }
+    }
+
+    backup::~backup() {
+        try {
+            finish();
+        } catch(...) {
+        }
+    }
+
+    bool backup::step(int nPage) {
+        if(!m_pBackup) {
+            throw database_exception("Backup object is already destroyed");
+        }
+
+        int err = sqlite3_backup_step(m_pBackup, nPage);
+        switch(err) {
+        case SQLITE_OK:
+            return true;
+        case SQLITE_DONE:
+            return false;
+        default:
+            throw database_exception_code(sqlite3_errmsg(get_to_handle()), err);
+        }
+    }
+
+    void backup::finish() {
+        if(!m_pBackup) {
+            return;
+        }
+
+        int err = sqlite3_backup_finish(m_pBackup);
+        if(err != SQLITE_OK) {
+            throw database_exception_code(sqlite3_errmsg(get_to_handle()), err);
+        }
+        m_pBackup = NULL;
+    }
+
+    sqlite3* backup::get_to_handle() const {
+        return private_accessor::get_handle(m_conn_to);
+    }
+}


### PR DESCRIPTION
Hello, this is my naive implementation concerning #19. It's currently only usuable and thorough review is necessary. I skipped descriptive comments and license blocks. For the latter part, feel free to add your own license blocks if these codes are accepted.

By the way, in ```sqlite::private_accessor```, the function ```acccess_check``` should be ```access_check``` (there's an extra 'c')