### PR TITLE
Enables out-of-source build

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5,7 +5,7 @@ AM_CXXFLAGS = -W -Wall -pedantic -W -std=c++0x
 
 lib_LTLIBRARIES = libvsqlitepp.la
 
-libvsqlitepp_la_CXXFLAGS = -I include $(AM_CXXFLAGS)
+libvsqlitepp_la_CXXFLAGS = -I $(srcdir)/include $(AM_CXXFLAGS)
 libvsqlitepp_la_LDFLAGS = -Wl,--no-as-needed -lsqlite3 -lboost_system -lboost_filesystem -Wl,-soname -Wl,libvsqlitepp.so.3 -version-info 3:0:0 
 libvsqlitepp_la_SOURCES = \
 	src/sqlite/backup.cpp \
@@ -20,7 +20,7 @@ libvsqlitepp_la_SOURCES = \
 	$(NULL)
 
 noinst_PROGRAMS=vsqlitepp_example
-vsqlitepp_example_CXXFLAGS=-I include $(AM_CXXFLAGS)
+vsqlitepp_example_CXXFLAGS=-I $(srcdir)/include $(AM_CXXFLAGS)
 vsqlitepp_example_LDADD = libvsqlitepp.la
 vsqlitepp_example_SOURCES = \
 	examples/sqlite_wrapper.cpp \


### PR DESCRIPTION
Current autotools configurations work only for in-source builds. Out-of-source builds fails due to incorrect include paths:

```Bash
$ ./autogen.sh 
Generating autobuild environment...
configure.ac:6: installing './compile'
configure.ac:6: installing './config.guess'
configure.ac:6: installing './config.sub'
configure.ac:3: installing './install-sh'
configure.ac:3: installing './missing'
Makefile.am: installing './depcomp'

$ mkdir build-linux && cd build-linux

$ ../configure 
checking for a BSD-compatible install... /usr/bin/install -c
checking whether build environment is sane... yes
checking for a thread-safe mkdir -p... /usr/bin/mkdir -p
checking for gawk... gawk
checking whether make sets $(MAKE)... yes
checking whether make supports nested variables... yes
checking for g++... g++
checking whether the C++ compiler works... yes
checking for C++ compiler default output file name... a.out
checking for suffix of executables... 
checking whether we are cross compiling... no
checking for suffix of object files... o
checking whether we are using the GNU C++ compiler... yes
checking whether g++ accepts -g... yes
checking for style of include used by make... GNU
checking dependency style of g++... gcc3
checking build system type... x86_64-unknown-linux-gnu
checking host system type... x86_64-unknown-linux-gnu
checking how to print strings... printf
checking for gcc... gcc
checking whether we are using the GNU C compiler... yes
checking whether gcc accepts -g... yes
checking for gcc option to accept ISO C89... none needed
checking whether gcc understands -c and -o together... yes
checking dependency style of gcc... gcc3
checking for a sed that does not truncate output... /usr/bin/sed
checking for grep that handles long lines and -e... /usr/bin/grep
checking for egrep... /usr/bin/grep -E
checking for fgrep... /usr/bin/grep -F
checking for ld used by gcc... /usr/bin/ld
checking if the linker (/usr/bin/ld) is GNU ld... yes
checking for BSD- or MS-compatible name lister (nm)... /usr/bin/nm -B
checking the name lister (/usr/bin/nm -B) interface... BSD nm
checking whether ln -s works... yes
checking the maximum length of command line arguments... 1572864
checking how to convert x86_64-unknown-linux-gnu file names to x86_64-unknown-linux-gnu format... func_convert_file_noop
checking how to convert x86_64-unknown-linux-gnu file names to toolchain format... func_convert_file_noop
checking for /usr/bin/ld option to reload object files... -r
checking for objdump... objdump
checking how to recognize dependent libraries... pass_all
checking for dlltool... no
checking how to associate runtime and link libraries... printf %s\n
checking for ar... ar
checking for archiver @FILE support... @
checking for strip... strip
checking for ranlib... ranlib
checking command to parse /usr/bin/nm -B output from gcc object... ok
checking for sysroot... no
checking for a working dd... /usr/bin/dd
checking how to truncate binary pipes... /usr/bin/dd bs=4096 count=1
checking for mt... no
checking if : is a manifest tool... no
checking how to run the C preprocessor... gcc -E
checking for ANSI C header files... yes
checking for sys/types.h... yes
checking for sys/stat.h... yes
checking for stdlib.h... yes
checking for string.h... yes
checking for memory.h... yes
checking for strings.h... yes
checking for inttypes.h... yes
checking for stdint.h... yes
checking for unistd.h... yes
checking for dlfcn.h... yes
checking for objdir... .libs
checking if gcc supports -fno-rtti -fno-exceptions... no
checking for gcc option to produce PIC... -fPIC -DPIC
checking if gcc PIC flag -fPIC -DPIC works... yes
checking if gcc static flag -static works... yes
checking if gcc supports -c -o file.o... yes
checking if gcc supports -c -o file.o... (cached) yes
checking whether the gcc linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
checking whether -lc should be explicitly linked in... no
checking dynamic linker characteristics... GNU/Linux ld.so
checking how to hardcode library paths into programs... immediate
checking whether stripping libraries is possible... yes
checking if libtool supports shared libraries... yes
checking whether to build shared libraries... yes
checking whether to build static libraries... yes
checking how to run the C++ preprocessor... g++ -E
checking for ld used by g++... /usr/bin/ld -m elf_x86_64
checking if the linker (/usr/bin/ld -m elf_x86_64) is GNU ld... yes
checking whether the g++ linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
checking for g++ option to produce PIC... -fPIC -DPIC
checking if g++ PIC flag -fPIC -DPIC works... yes
checking if g++ static flag -static works... yes
checking if g++ supports -c -o file.o... yes
checking if g++ supports -c -o file.o... (cached) yes
checking whether the g++ linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
checking dynamic linker characteristics... (cached) GNU/Linux ld.so
checking how to hardcode library paths into programs... immediate
checking that generated files are newer than configure... done
configure: creating ./config.status
config.status: creating Makefile
config.status: creating include/Makefile
config.status: executing depfiles commands
config.status: executing libtool commands

$ make
Making all in include
make[1]: Entering directory '/home/yen/tmp/vsqlite--_yen/build-linux/include'
make[1]: Nothing to be done for 'all'.
make[1]: Leaving directory '/home/yen/tmp/vsqlite--_yen/build-linux/include'
make[1]: Entering directory '/home/yen/tmp/vsqlite--_yen/build-linux'
/bin/sh ./libtool  --tag=CXX   --mode=compile g++ -DPACKAGE_NAME=\"libvsqlite++\" -DPACKAGE_TARNAME=\"vsqlite++\" -DPACKAGE_VERSION=\"0.3.13\" -DPACKAGE_STRING=\"libvsqlite++\ 0.3.13\" -DPACKAGE_BUGREPORT=\"evilissimo@gmail.com\" -DPACKAGE_URL=\"http://github.com/vinzenz/vsqlite--\" -DPACKAGE=\"vsqlite++\" -DVERSION=\"0.3.13\" -DSTDC_HEADERS=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_MEMORY_H=1 -DHAVE_STRINGS_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_UNISTD_H=1 -DHAVE_DLFCN_H=1 -DLT_OBJDIR=\".libs/\" -I. -I..    -I include -W -Wall -pedantic -W -std=c++0x -g -O2 -MT src/sqlite/libvsqlitepp_la-backup.lo -MD -MP -MF src/sqlite/.deps/libvsqlitepp_la-backup.Tpo -c -o src/sqlite/libvsqlitepp_la-backup.lo `test -f 'src/sqlite/backup.cpp' || echo '../'`src/sqlite/backup.cpp
libtool: compile:  g++ -DPACKAGE_NAME=\"libvsqlite++\" -DPACKAGE_TARNAME=\"vsqlite++\" -DPACKAGE_VERSION=\"0.3.13\" "-DPACKAGE_STRING=\"libvsqlite++ 0.3.13\"" -DPACKAGE_BUGREPORT=\"evilissimo@gmail.com\" -DPACKAGE_URL=\"http://github.com/vinzenz/vsqlite--\" -DPACKAGE=\"vsqlite++\" -DVERSION=\"0.3.13\" -DSTDC_HEADERS=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_MEMORY_H=1 -DHAVE_STRINGS_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_UNISTD_H=1 -DHAVE_DLFCN_H=1 -DLT_OBJDIR=\".libs/\" -I. -I.. -I include -W -Wall -pedantic -W -std=c++0x -g -O2 -MT src/sqlite/libvsqlitepp_la-backup.lo -MD -MP -MF src/sqlite/.deps/libvsqlitepp_la-backup.Tpo -c ../src/sqlite/backup.cpp  -fPIC -DPIC -o src/sqlite/.libs/libvsqlitepp_la-backup.o
../src/sqlite/backup.cpp:1:29: fatal error: sqlite/backup.hpp: No such file or directory
 #include <sqlite/backup.hpp>
                             ^
compilation terminated.
Makefile:602: recipe for target 'src/sqlite/libvsqlitepp_la-backup.lo' failed
make[1]: *** [src/sqlite/libvsqlitepp_la-backup.lo] Error 1
make[1]: Leaving directory '/home/yen/tmp/vsqlite--_yen/build-linux'
Makefile:695: recipe for target 'all-recursive' failed
make: *** [all-recursive] Error 1

```

With this quick fix, the build process goes fluently.

I need a correct out-of-source build system because I'd like to package the mingw-w64 version on Arch Linux, and according to the packaging guideline [1], out-of-source builds are preferred.

[1] https://wiki.archlinux.org/index.php/MinGW_package_guidelines