### PR TITLE
Changed While loops in example to Do While loops

### DIFF
--- a/examples/sqlite_wrapper.cpp
+++ b/examples/sqlite_wrapper.cpp
@@ -61,14 +61,14 @@ int main()
         sqlite::query q(con,"SELECT * from test;");
 
         boost::shared_ptr<sqlite::result> res = q.get_result();
-        while(res->next_row()) {
+        do {
             std::cout << res->get_int(0) << "|" << res->get_string(1) << std::endl;
-        }
+        } while(res->next_row());
 
         res->reset();
-        while(res->next_row()) {
+        do {
             std::cout << res->get_int(0) << "|" << res->get_string(1) << std::endl;
-        }
+        } while(res->next_row());
 
         sqlite::backup backup_op(con_memory, con);
         backup_op.step();
@@ -77,9 +77,9 @@ int main()
         sqlite::query q_memory(con_memory, "SELECT * FROM test;");
 
         boost::shared_ptr<sqlite::result> res2 = q_memory.get_result();
-        while(res2->next_row()) {
+        do {
             std::cout << res2->get_int(0) << "|" << res2->get_string(1) << std::endl;
-        }
+        } while(res2->next_row());
 
         sqlite::execute(con,"DROP TABLE test;",true);
 


### PR DESCRIPTION
The while loops that were in the documentation skip the first row that
is returned (as next_row() moves the result object to the next row - as
opposed to merely returning if there are any rows left).