### PR TITLE
Use v2 prepare for better errors and performance.

### DIFF
--- a/src/sqlite/command.cpp
+++ b/src/sqlite/command.cpp
@@ -71,7 +71,7 @@ namespace sqlite{
         if(stmt)
             finalize();
         const char * tail = 0;
-        int err = sqlite3_prepare(get_handle(),m_sql.c_str(),-1,&stmt,&tail);
+        int err = sqlite3_prepare_v2(get_handle(),m_sql.c_str(),-1,&stmt,&tail);
         if(err != SQLITE_OK)
             throw database_exception_code(sqlite3_errmsg(get_handle()), err);
     }


### PR DESCRIPTION
The v2 version will print more detailed error messages,
it will also allow recompilation of the SQL when the DB
changes underneith the statement.