### PR TITLE
Ensure crash in commit/rollback does not try twice

### DIFF
--- a/include/sqlite/transaction.hpp
+++ b/include/sqlite/transaction.hpp
@@ -100,10 +100,17 @@ namespace sqlite{
           * \return \c true if transaction is still active, \c false otherwise
           */
         bool isActive() const { return m_isActive; }
+        /** \brief Allow to check if transaction handled by this object is
+          * currently in the middle of a COMMIT/Rollback operation.  It is used
+          * for the handling of exceptions during commit/rollback operations.
+          * \return \c true if transaction is committing/rolling back, \c false otherwise
+          */
+        bool isEnding() const { return m_isEnding; }
     private:
         void exec(std::string const &);
         connection & m_con;
         bool m_isActive; ///< if \c true there is a transaction currently opened
+        bool m_isEnding; ///< if \c true there is a transaction is currently ending
     };
 }
 


### PR DESCRIPTION
It is possible that if during the rollback or commit command
that there may be a disk error that will cause SQLite to return
an error.  When that happens we must not attempt to rollback again.

This was seen when running multi-threaded and a bug in some code
resulted in the SQLite file descripter being closed in the middle of
a transaction.