### PR TITLE
Fix backup handle release when finish reports an error

### DIFF
--- a/src/sqlite/backup.cpp
+++ b/src/sqlite/backup.cpp
@@ -43,15 +43,19 @@ inline namespace v2 {
     }
 
     void backup::finish() {
-        if (!m_pBackup) {
+        // sqlite3_backup_finish() releases the backup regardless of its return
+        // code, so the handle has to be dropped before it is used again - even
+        // if reporting the result ends up throwing.
+        sqlite3_backup *pBackup = m_pBackup;
+        m_pBackup               = NULL;
+        if (!pBackup) {
             return;
         }
 
-        int err = sqlite3_backup_finish(m_pBackup);
+        int err = sqlite3_backup_finish(pBackup);
         if (err != SQLITE_OK) {
             throw database_exception_code(sqlite3_errmsg(get_to_handle()), err);
         }
-        m_pBackup = NULL;
     }
 
     sqlite3 *backup::get_to_handle() const {

--- a/tests/test_backup.cpp
+++ b/tests/test_backup.cpp
@@ -3,6 +3,7 @@
 #include <sqlite/backup.hpp>
 #include <sqlite/command.hpp>
 #include <sqlite/connection.hpp>
+#include <sqlite/database_exception.hpp>
 #include <sqlite/execute.hpp>
 
 using namespace testhelpers;
@@ -34,4 +35,55 @@ TEST(BackupTest, StepAfterFinishThrows) {
     sqlite::backup job(dst, src);
     job.finish();
     EXPECT_THROW(job.step(), sqlite::database_exception);
+    job.finish();
+}
+
+namespace {
+// Creates a destination file first so that it can be re-opened read-only.
+void init_readonly_destination(TempFile const &dst_file) {
+    sqlite::connection init(dst_file.string());
+    sqlite::execute(init, "CREATE TABLE placeholder(id INTEGER PRIMARY KEY);", true);
+}
+} // namespace
+
+TEST(BackupTest, FailedBackupFinishThenDestructionDoesNotCrash) {
+    TempFile src_file("backup_fail_src");
+    TempFile dst_file("backup_fail_dst");
+    init_readonly_destination(dst_file);
+
+    sqlite::connection src(src_file.string());
+    sqlite::execute(src, "CREATE TABLE data(id INTEGER PRIMARY KEY, value TEXT);", true);
+    sqlite::execute(src, "INSERT INTO data(value) VALUES ('one'), ('two');", true);
+
+    sqlite::connection dst(dst_file.string(), sqlite::open_mode::open_readonly);
+    sqlite::backup job(dst, src);
+    EXPECT_THROW(job.step(), sqlite::database_exception);
+
+    try {
+        job.finish();
+        ADD_FAILURE() << "finish() should have reported the backup failure";
+    } catch (sqlite::database_exception_code const &e) {
+        EXPECT_EQ(e.error_code(), SQLITE_READONLY);
+    }
+
+    // The backup handle is released by the first finish() call even though it
+    // reported an error: repeated calls and the upcoming destruction must not
+    // operate on the released handle anymore.
+    job.finish();
+}
+
+TEST(BackupTest, DestructorFinishesFailedBackupWithoutExplicitFinish) {
+    TempFile src_file("backup_dtor_src");
+    TempFile dst_file("backup_dtor_dst");
+    init_readonly_destination(dst_file);
+
+    sqlite::connection src(src_file.string());
+    sqlite::execute(src, "CREATE TABLE data(id INTEGER PRIMARY KEY, value TEXT);", true);
+    sqlite::execute(src, "INSERT INTO data(value) VALUES ('one'), ('two');", true);
+
+    sqlite::connection dst(dst_file.string(), sqlite::open_mode::open_readonly);
+    sqlite::backup job(dst, src);
+    EXPECT_THROW(job.step(), sqlite::database_exception);
+    // No explicit finish() here: the destructor releases the failed backup and
+    // must survive the error it reports.
 }


### PR DESCRIPTION
## Summary
- Release the SQLite backup handle before propagating `sqlite3_backup_finish()` errors.
- Add regression coverage for repeated finish calls and destructor cleanup after failed backups.

## Testing
- Added tests covering failed backup cleanup and destruction without explicit finish.

Fixes #54
