### PR TITLE
Fix SQLITE_SERIALIZE_NOCOPY buffer ownership

### DIFF
--- a/include/sqlite/serialization.hpp
+++ b/include/sqlite/serialization.hpp
@@ -54,6 +54,12 @@ inline namespace v2 {
     /**
      * @brief Copies the complete database image for @p schema into a byte vector.
      *
+     * The returned vector always owns its bytes. When @p flags contains
+     * `SQLITE_SERIALIZE_NOCOPY`, SQLite returns its own in-memory image without making a
+     * copy; those bytes are copied into the result and the buffer remains owned by the
+     * connection. Because no allocation is made in that case, an exception is thrown when
+     * no contiguous in-memory image exists (e.g. for a file-backed database).
+     *
      * @param con Open connection whose schema should be serialized.
      * @param schema Logical database name (e.g. `"main"` or `"temp"`).
      * @param flags Optional SQLite serialization flags.

--- a/src/sqlite/serialization.cpp
+++ b/src/sqlite/serialization.cpp
@@ -99,10 +99,20 @@ inline namespace v2 {
         auto fn             = serialization_symbols().serialize;
         unsigned char *blob = fn ? fn(get_handle(con), normalized.c_str(), &size, flags) : nullptr;
         if (!blob) {
+            if (flags & SQLITE_SERIALIZE_NOCOPY) {
+                throw database_exception(
+                    "Failed to serialize database image: no contiguous in-memory image "
+                    "available for SQLITE_SERIALIZE_NOCOPY.");
+            }
             throw database_exception("Failed to serialize database image.");
         }
         std::vector<unsigned char> out(blob, blob + size);
-        sqlite3_free(blob);
+        // With SQLITE_SERIALIZE_NOCOPY the returned buffer is the connection's own
+        // storage and stays owned by SQLite — freeing it would corrupt the live
+        // database and cause a double free when the connection is closed.
+        if ((flags & SQLITE_SERIALIZE_NOCOPY) == 0) {
+            sqlite3_free(blob);
+        }
         return out;
     }
 

--- a/tests/test_serialization.cpp
+++ b/tests/test_serialization.cpp
@@ -1,6 +1,7 @@
 #include "test_common.hpp"
 
 #include <sqlite/connection.hpp>
+#include <sqlite/database_exception.hpp>
 #include <sqlite/execute.hpp>
 #include <sqlite/serialization.hpp>
 
@@ -21,4 +22,65 @@ TEST(SerializationTest, RoundTripsInMemoryDatabase) {
     auto res = q.get_result();
     ASSERT_TRUE(res->next_row());
     EXPECT_EQ(res->get<int>(0), 2);
+}
+
+TEST(SerializationTest, NoCopyKeepsDeserializedDatabaseUsable) {
+    if (!sqlite::serialization_supported()) {
+        GTEST_SKIP() << "SQLite serialization APIs not available in this build.";
+    }
+    sqlite::connection src(":memory:");
+    sqlite::execute(src, "CREATE TABLE data(id INTEGER PRIMARY KEY, value TEXT);", true);
+    sqlite::execute(src, "INSERT INTO data(value) VALUES ('one'), ('two');", true);
+    auto image = sqlite::serialize(src);
+
+    sqlite::connection dest(":memory:");
+    sqlite::deserialize(dest, image);
+
+    // SQLITE_SERIALIZE_NOCOPY returns the connection's own storage; the wrapper must
+    // copy the bytes without freeing the buffer it does not own.
+    auto nocopy = sqlite::serialize(dest, "main", SQLITE_SERIALIZE_NOCOPY);
+    ASSERT_FALSE(nocopy.empty());
+
+    // The connection stays usable afterwards and closes cleanly on destruction.
+    sqlite::query q(dest, "SELECT COUNT(*) FROM data;");
+    auto res = q.get_result();
+    ASSERT_TRUE(res->next_row());
+    EXPECT_EQ(res->get<int>(0), 2);
+}
+
+TEST(SerializationTest, NoCopyMatchesOwningCopyImage) {
+    if (!sqlite::serialization_supported()) {
+        GTEST_SKIP() << "SQLite serialization APIs not available in this build.";
+    }
+    sqlite::connection src(":memory:");
+    sqlite::execute(src, "CREATE TABLE data(id INTEGER PRIMARY KEY, value TEXT);", true);
+    sqlite::execute(src, "INSERT INTO data(value) VALUES ('one'), ('two');", true);
+    auto image = sqlite::serialize(src);
+
+    sqlite::connection dest(":memory:");
+    sqlite::deserialize(dest, image);
+
+    auto copied = sqlite::serialize(dest);
+    auto nocopy = sqlite::serialize(dest, "main", SQLITE_SERIALIZE_NOCOPY);
+    ASSERT_FALSE(copied.empty());
+    EXPECT_EQ(nocopy, copied);
+}
+
+TEST(SerializationTest, NoCopyWithoutContiguousImageThrows) {
+    if (!sqlite::serialization_supported()) {
+        GTEST_SKIP() << "SQLite serialization APIs not available in this build.";
+    }
+    TempFile file("serialization_nocopy_file");
+    sqlite::connection con(file.string());
+    sqlite::execute(con, "CREATE TABLE data(id INTEGER PRIMARY KEY);", true);
+
+    // A file-backed database has no contiguous in-memory image, so
+    // SQLITE_SERIALIZE_NOCOPY yields NULL from sqlite3_serialize.
+    EXPECT_THROW(sqlite::serialize(con, "main", SQLITE_SERIALIZE_NOCOPY),
+                 sqlite::database_exception);
+
+    // The connection remains usable, and the owning-copy path still works.
+    EXPECT_EQ(count_rows(con, "data"), 0);
+    auto image = sqlite::serialize(con);
+    EXPECT_FALSE(image.empty());
 }


### PR DESCRIPTION
## Summary

- Preserve SQLite-owned buffers returned with `SQLITE_SERIALIZE_NOCOPY`.
- Document no-copy behavior and errors for unavailable in-memory images.
- Add coverage for database usability, image parity, and file-backed failures.

## Testing

- Added serialization tests for no-copy ownership and connection usability.
- Verified no-copy output matches the owning-copy image.
- Verified file-backed databases throw for `SQLITE_SERIALIZE_NOCOPY` while remaining usable.

Fixes #53