### PR TITLE
Fix function callback ownership on registration failure

### DIFF
--- a/include/sqlite/function.hpp
+++ b/include/sqlite/function.hpp
@@ -468,16 +468,18 @@ inline namespace v2 {
         std::string name_buffer(name);
         auto text_rep = detail::compose_text_rep(options);
 
+        // Hand ownership to SQLite before checking the result: its xDestroy callback runs
+        // on failed registration, on replacement, and on connection close alike.
+        auto *holder_ptr = holder.release();
+
         int rc = sqlite3_create_function_v2(handle, name_buffer.c_str(), arity, text_rep,
-                                            holder.get(), &detail::function_entry<callable_t>,
+                                            holder_ptr, &detail::function_entry<callable_t>,
                                             nullptr, nullptr, &detail::destroy_holder<callable_t>);
 
         if (rc != SQLITE_OK) {
             auto err = sqlite3_errmsg(handle);
             throw database_exception_code(err ? err : detail::make_function_error(name), rc);
         }
-
-        holder.release();
     }
 
 } // namespace v2

--- a/tests/test_function.cpp
+++ b/tests/test_function.cpp
@@ -29,3 +29,72 @@ TEST(FunctionTest, OptionalAndBlobArguments) {
     insert % data;
     EXPECT_TRUE(insert.step_once());
 }
+
+namespace {
+
+/// Move-only callable whose destructor increments `destroyed` exactly once.
+/// Moved-from instances hand the counter over and stay silent.
+struct tracked_callable {
+    explicit tracked_callable(int *destroyed_count) : destroyed(destroyed_count) {}
+
+    tracked_callable(tracked_callable &&other) noexcept : destroyed(other.destroyed) {
+        other.destroyed = nullptr;
+    }
+    tracked_callable(tracked_callable const &)            = delete;
+    tracked_callable &operator=(tracked_callable const &) = delete;
+    tracked_callable &operator=(tracked_callable &&)      = delete;
+
+    ~tracked_callable() {
+        if (destroyed) {
+            ++*destroyed;
+        }
+    }
+
+    int operator()() const {
+        return 1;
+    }
+
+    int *destroyed;
+};
+
+} // namespace
+
+TEST(FunctionTest, OverlongFunctionNameIsCatchable) {
+    sqlite::connection conn(":memory:");
+    int destroyed = 0;
+    try {
+        sqlite::create_function(conn, std::string(256, 'x'), tracked_callable{&destroyed});
+        FAIL() << "Expected registration of an overlong function name to fail.";
+    } catch (sqlite::database_exception_code const &ex) {
+        EXPECT_EQ(ex.error_code(), SQLITE_MISUSE);
+        EXPECT_EQ(destroyed, 1);
+    }
+}
+
+TEST(FunctionTest, ReplacementDestroysPreviousCallbackOnce) {
+    int first_destroyed  = 0;
+    int second_destroyed = 0;
+    {
+        sqlite::connection conn(":memory:");
+        sqlite::create_function(conn, "tracker", tracked_callable{&first_destroyed});
+        sqlite::create_function(conn, "tracker", tracked_callable{&second_destroyed});
+        EXPECT_EQ(first_destroyed, 1);
+        EXPECT_EQ(second_destroyed, 0);
+
+        sqlite::query q(conn, "SELECT tracker();");
+        auto res = q.get_result();
+        ASSERT_TRUE(res->next_row());
+        EXPECT_EQ(res->get<int>(0), 1);
+    }
+    EXPECT_EQ(second_destroyed, 1);
+}
+
+TEST(FunctionTest, ConnectionCloseDestroysCallbackOnce) {
+    int destroyed = 0;
+    {
+        sqlite::connection conn(":memory:");
+        sqlite::create_function(conn, "tracker", tracked_callable{&destroyed});
+        EXPECT_EQ(destroyed, 0);
+    }
+    EXPECT_EQ(destroyed, 1);
+}


### PR DESCRIPTION
## Summary

- Transfer callback ownership to SQLite before function registration: `sqlite3_create_function_v2()` invokes the `xDestroy` callback on failed registration, so releasing the `unique_ptr` only after success double-frees the holder.
- `xDestroy` now owns cleanup on all paths (failed registration, replacement, connection close). Error code and message handling are unchanged.
- Add regression tests for callback lifetime: overlong function name produces a catchable `SQLITE_MISUSE` exception with the callback destroyed exactly once, replacement destroys the previous callback once, and connection close destroys the callback once.

Fixes #50

## Testing

- Full unit suite (44 tests) on Linux, GCC 15.2.1, C++20, Debug shared build with bundled SQLite.
- Failure cases run clean under AddressSanitizer (leak detection on); pre-fix code reports heap-use-after-free in the same scenario.
- The issue's repro now catches the exception and exits 0 instead of aborting with a double free.