### PR TITLE
Open file: URI database names as SQLite URIs

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,11 @@
+# vsqlite++ (unreleased)
+
+- Fixed named in-memory database URIs (`file:name?mode=memory&cache=shared`) being
+  created as ordinary files on disk instead of living in memory.
+- Database names starting with `file:` are now interpreted as SQLite URIs: path
+  validation uses the decoded URI path and the `mode=memory` query parameter is
+  matched strictly. All other names keep being treated as literal filenames.
+
 # vsqlite++ 0.4.2
 
 - Fixed a statement ownership regression in 0.4.1 that finalized prepared statements immediately

--- a/include/sqlite/connection.hpp
+++ b/include/sqlite/connection.hpp
@@ -59,6 +59,12 @@ inline namespace v2 {
      * Further it has to be passed to all classes since it represents the
      * connection to the database and contains the internal needed handle, so
      * you can see a connection object as handle to the database
+     *
+     * A database name starting with "file:" is interpreted as a SQLite URI
+     * (see https://www.sqlite.org/uri.html), e.g.
+     * "file:name?mode=memory&cache=shared" opens a shared in-memory database.
+     * Any other name is used as a literal filename.
+     *
      * An object of this class is not copyable
      */
     struct connection {
@@ -98,7 +104,12 @@ inline namespace v2 {
          * the object of this class. It is possible to attach up to 10 times
          * the same database file with different aliases
          * \param db database filename of the database should be attached
+         *           following the same rules as the connection constructors
          * \param database_alias alias which should be used
+         *
+         * \remarks SQLite interprets "file:" URIs in ATTACH only when the
+         * connection itself was opened from a "file:" URI (or when URI
+         * support is enabled globally in SQLite).
          */
         void attach(std::string const &db, std::string const &database_alias);
 

--- a/src/sqlite/connection.cpp
+++ b/src/sqlite/connection.cpp
@@ -30,6 +30,7 @@
  POSSIBILITY OF SUCH DAMAGE.
 
 ##############################################################################*/
+#include <algorithm>
 #include <filesystem>
 #include <format>
 #include <string_view>
@@ -43,20 +44,122 @@
 #include <iostream>
 
 namespace {
-bool is_special_database(std::string_view db) {
-    if (db == ":memory:") {
-        return true;
+// Classification of a database name handed to connection::open() or attach().
+struct database_name_info {
+    bool is_uri = false; ///< the name is a "file:" URI
+    bool memory = false; ///< the database lives in memory only
+    std::string path;    ///< filesystem path (percent-decoded for URIs); empty
+                         ///< when the database has no file on disk
+};
+
+// SQLite interprets a database name as a URI exactly when it starts with
+// "file:" and URI interpretation is enabled (see make_open_flags()).
+bool is_uri_database(std::string_view db) {
+    return db.rfind("file:", 0) == 0;
+}
+
+int hex_digit_value(char c) {
+    if (c >= '0' && c <= '9') {
+        return c - '0';
     }
-    if (db.rfind("file:", 0) == 0) {
-        auto query_pos = db.find('?');
-        if (query_pos != std::string_view::npos) {
-            auto params = db.substr(query_pos + 1);
-            if (params.find("mode=memory") != std::string_view::npos) {
-                return true;
+    if (c >= 'a' && c <= 'f') {
+        return c - 'a' + 10;
+    }
+    if (c >= 'A' && c <= 'F') {
+        return c - 'A' + 10;
+    }
+    return -1;
+}
+
+// Decodes %HH escapes the way SQLite does: a "%00" escape ends the component,
+// and a '%' not followed by two hex digits is kept literal.
+std::string percent_decode(std::string_view text) {
+    std::string decoded;
+    decoded.reserve(text.size());
+    for (std::size_t i = 0; i < text.size(); ++i) {
+        if (text[i] == '%' && i + 2 < text.size()) {
+            int high = hex_digit_value(text[i + 1]);
+            int low  = hex_digit_value(text[i + 2]);
+            if (high >= 0 && low >= 0) {
+                char octet = static_cast<char>((high << 4) | low);
+                if (octet == '\0') {
+                    break;
+                }
+                decoded.push_back(octet);
+                i += 2;
+                continue;
             }
         }
+        decoded.push_back(text[i]);
     }
-    return false;
+    return decoded;
+}
+
+// Splits a database name the same way sqlite3_open_v2() does for URIs, so that
+// in-memory detection and path validation agree with what SQLite will make of
+// the name.
+database_name_info classify_database_name(std::string_view db) {
+    database_name_info info;
+    if (db == ":memory:") {
+        info.memory = true;
+        return info;
+    }
+    if (!is_uri_database(db)) {
+        return info;
+    }
+    info.is_uri = true;
+    std::string_view rest = db.substr(5);
+
+    // Optional authority: SQLite accepts an empty one or "localhost" only and
+    // rejects anything else when opening.
+    if (rest.size() >= 2 && rest[0] == '/' && rest[1] == '/') {
+        rest.remove_prefix(2);
+        auto authority_end = std::min(rest.find('/'), rest.size());
+        auto authority     = rest.substr(0, authority_end);
+        if (!authority.empty() && authority != "localhost") {
+            return info;
+        }
+        rest.remove_prefix(authority_end);
+    }
+
+    auto path_end = rest.find_first_of("?#");
+    info.path =
+        percent_decode(path_end == std::string_view::npos ? rest : rest.substr(0, path_end));
+    if (info.path == ":memory:") {
+        info.memory = true; // "file::memory:" names an in-memory database
+        return info;
+    }
+    if (path_end == std::string_view::npos || rest[path_end] != '?') {
+        return info; // no query component
+    }
+
+    // The query is made of &-separated name[=value] pairs; both parts are
+    // percent-decoded. SQLite applies the parameters in order, so a repeated
+    // "mode" parameter overrules the earlier ones.
+    std::string_view query = rest.substr(path_end + 1);
+    auto fragment          = query.find('#');
+    if (fragment != std::string_view::npos) {
+        query = query.substr(0, fragment);
+    }
+
+    std::string mode;
+    bool has_mode         = false;
+    std::size_t param_pos = 0;
+    while (param_pos < query.size()) {
+        auto next  = query.find('&', param_pos);
+        auto param = query.substr(param_pos,
+                                  next == std::string_view::npos ? next : next - param_pos);
+        param_pos  = next == std::string_view::npos ? query.size() : next + 1;
+        auto equals = param.find('=');
+        if (percent_decode(param.substr(0, equals)) != "mode") {
+            continue;
+        }
+        has_mode = true;
+        mode     = equals == std::string_view::npos ? std::string()
+                                                    : percent_decode(param.substr(equals + 1));
+    }
+    info.memory = has_mode && mode == "memory";
+    return info;
 }
 
 std::string describe_path(std::filesystem::path const &path) {
@@ -94,13 +197,17 @@ void ensure_parent_directory_safe(std::filesystem::path const &path, std::string
 
 void validate_db_path(std::string const &db, bool require_exists,
                       sqlite::filesystem_adapter_ptr const &fs) {
-    if (is_special_database(db)) {
+    auto info = classify_database_name(db);
+    if (info.memory) {
         return;
+    }
+    if (info.is_uri && info.path.empty()) {
+        return; // a "file:" URI without a path opens a temporary database
     }
     if (db.empty()) {
         throw sqlite::database_exception("Database path must not be empty.");
     }
-    std::filesystem::path path(db);
+    std::filesystem::path path(info.is_uri ? info.path : db);
     ensure_parent_directory_safe(path, db, fs);
     auto entry     = fs->status(path);
     auto not_found = std::make_error_code(std::errc::no_such_file_or_directory);
@@ -126,6 +233,12 @@ void validate_db_path(std::string const &db, bool require_exists,
 
 int make_open_flags(bool readonly, bool allow_create) {
     int flags = SQLITE_OPEN_FULLMUTEX;
+    // Names starting with "file:" are SQLite URIs (e.g. a named in-memory
+    // database "file:name?mode=memory&cache=shared"). SQLite only applies URI
+    // interpretation to those names and passes every other name through
+    // literally, so ordinary filenames behave exactly as before. This also
+    // makes ATTACH honor "file:" URIs on connections opened from such a URI.
+    flags |= SQLITE_OPEN_URI;
 #ifndef VSQLITE_ALLOW_FOLLOW_SYMLINKS
     flags |= SQLITE_OPEN_NOFOLLOW;
 #endif
@@ -196,8 +309,11 @@ inline namespace v2 {
     }
 
     void connection::open(std::string const &db, sqlite::open_mode open_mode) {
-        bool special = is_special_database(db);
-        if (!special) {
+        auto info = classify_database_name(db);
+        // In-memory databases and "file:" URIs without a path never touch the
+        // disk, so they need neither path validation nor an existing file.
+        bool disk_backed = !info.memory && !(info.is_uri && info.path.empty());
+        if (disk_backed) {
             validate_db_path(db,
                              open_mode == sqlite::open_mode::open_existing ||
                                  open_mode == sqlite::open_mode::open_readonly,
@@ -205,28 +321,29 @@ inline namespace v2 {
         }
 
         std::filesystem::path disk_path =
-            special ? std::filesystem::path() : std::filesystem::path(db);
+            disk_backed ? std::filesystem::path(info.is_uri ? info.path : db)
+                        : std::filesystem::path();
         std::error_code ec;
-        bool exists = special ? false : std::filesystem::exists(disk_path, ec);
-        if (ec && !special) {
+        bool exists = disk_backed ? std::filesystem::exists(disk_path, ec) : false;
+        if (disk_backed && ec) {
             throw database_system_error("Failed to inspect database '" + db + "'", ec.value());
         }
 
         switch (open_mode) {
         case sqlite::open_mode::open_readonly:
-            if (!exists && !special) {
+            if (disk_backed && !exists) {
                 throw database_exception("Read-only database '" + db + "' does not exist");
             }
             open_with_flags(db, make_open_flags(true, false));
             return;
         case sqlite::open_mode::open_existing:
-            if (!exists && !special) {
+            if (disk_backed && !exists) {
                 throw database_exception("Database '" + db + "' does not exist");
             }
             open_with_flags(db, make_open_flags(false, false));
             return;
         case sqlite::open_mode::always_create:
-            if (exists && !special) {
+            if (exists) {
                 auto entry = filesystem->status(disk_path);
                 if (entry.error) {
                     throw database_system_error("Failed to inspect existing database '" + db + "'",

--- a/tests/test_common.hpp
+++ b/tests/test_common.hpp
@@ -168,10 +168,16 @@ inline void dump_table_info(sqlite::connection &con, std::string_view table) {
     }
 }
 
-inline std::string unique_memory_uri() {
+inline std::string unique_memory_uri(bool absolute = false) {
     static std::atomic<uint64_t> counter{0};
     std::ostringstream oss;
-    oss << "file:memdb_" << counter++ << "?mode=memory&cache=shared";
+    oss << "file:";
+    if (absolute) {
+        oss << (test_root() / ("memdb_" + std::to_string(counter++))).string();
+    } else {
+        oss << "memdb_" << counter++;
+    }
+    oss << "?mode=memory&cache=shared";
     return oss.str();
 }
 

--- a/tests/test_connection.cpp
+++ b/tests/test_connection.cpp
@@ -149,6 +149,101 @@ TEST(ConnectionTest, SpecialMemoryUri) {
     auto uri = unique_memory_uri();
     sqlite::connection conn(uri);
     sqlite::execute(conn, "CREATE TABLE IF NOT EXISTS memtest(id INTEGER);", true);
+    // A named memory URI must never materialize as a file on disk.
+    std::error_code ec;
+    EXPECT_FALSE(std::filesystem::exists(std::filesystem::path(uri), ec));
+}
+
+TEST(ConnectionTest, NamedMemoryUriSharingAcrossConnections) {
+    auto uri = unique_memory_uri();
+    sqlite::connection first(uri);
+    sqlite::execute(first, "CREATE TABLE memtest(id INTEGER);", true);
+    sqlite::execute(first, "INSERT INTO memtest VALUES (42);", true);
+
+    std::error_code ec;
+    EXPECT_FALSE(std::filesystem::exists(std::filesystem::path(uri), ec));
+
+    {
+        sqlite::connection second(uri);
+        EXPECT_EQ(count_rows(second, "memtest"), 1);
+        sqlite::execute(second, "INSERT INTO memtest VALUES (43);", true);
+    }
+    // The database must stay alive while at least one connection remains open.
+    EXPECT_EQ(count_rows(first, "memtest"), 2);
+    EXPECT_FALSE(std::filesystem::exists(std::filesystem::path(uri), ec));
+}
+
+TEST(ConnectionTest, MemoryUriRequiresExactModeParameter) {
+    TempFile file("uri_not_memory");
+    // "?xmode=memory" is not a mode parameter: the URI names a real file.
+    {
+        sqlite::connection conn("file:" + file.path.string() + "?xmode=memory");
+        sqlite::execute(conn, "CREATE TABLE diskcheck(id INTEGER);", true);
+    }
+    EXPECT_TRUE(std::filesystem::exists(file.path));
+
+    // Unknown mode values are rejected by SQLite when opening.
+    EXPECT_THROW(sqlite::connection bad("file:" + file.path.string() + "?mode=bogus"),
+                 sqlite::database_exception);
+}
+
+TEST(ConnectionTest, PercentEncodedMemoryParameter) {
+    static std::atomic<uint64_t> counter{0};
+    auto name = (test_root() / ("encoded_mem_" + std::to_string(counter++))).string();
+    // "%6d" decodes to 'm', so the effective mode parameter is "memory".
+    std::string uri = "file:" + name + "?mode=%6demory&cache=shared";
+    sqlite::connection conn(uri);
+    sqlite::execute(conn, "CREATE TABLE memtest(id INTEGER);", true);
+
+    std::error_code ec;
+    EXPECT_FALSE(std::filesystem::exists(name, ec));
+}
+
+TEST(ConnectionTest, MemoryUriNeedsNoExistingDirectory) {
+    auto missing = test_root() / "no_such_parent_dir" / "mem.db";
+    std::error_code ec;
+    std::filesystem::remove_all(missing.parent_path(), ec);
+    // With mode=memory the path is a pure database name: no directory checks.
+    sqlite::connection conn("file:" + missing.string() + "?mode=memory");
+    sqlite::execute(conn, "CREATE TABLE memtest(id INTEGER);", true);
+    EXPECT_FALSE(std::filesystem::exists(missing, ec));
+}
+
+TEST(ConnectionTest, FileUriPathIsValidated) {
+    auto missing = test_root() / "no_such_parent_dir" / "db.sqlite";
+    std::error_code ec;
+    std::filesystem::remove_all(missing.parent_path(), ec);
+    // Without mode=memory the URI path is validated like any other path.
+    EXPECT_THROW(sqlite::connection conn("file:" + missing.string()),
+                 sqlite::database_exception);
+
+    TempFile file("uri_existing");
+    {
+        sqlite::connection conn("file:" + file.path.string());
+        sqlite::execute(conn, "CREATE TABLE t(id INTEGER);", true);
+    }
+    sqlite::connection readonly("file:" + file.path.string(), sqlite::open_mode::open_readonly);
+    EXPECT_NO_THROW(sqlite::execute(readonly, "SELECT COUNT(*) FROM t;", true));
+
+    TempFile absent("uri_missing");
+    std::filesystem::remove(absent.path, ec);
+    EXPECT_THROW(sqlite::connection fail("file:" + absent.path.string(),
+                                         sqlite::open_mode::open_existing),
+                 sqlite::database_exception);
+}
+
+TEST(ConnectionTest, AttachMemoryUri) {
+    sqlite::connection main(unique_memory_uri());
+    sqlite::execute(main, "CREATE TABLE base(id INTEGER);", true);
+
+    auto uri = unique_memory_uri();
+    ASSERT_NO_THROW(main.attach(uri, "mem"));
+    EXPECT_NO_THROW(sqlite::execute(main, "CREATE TABLE mem.attached(id INTEGER);", true));
+    EXPECT_NO_THROW(sqlite::execute(main, "INSERT INTO mem.attached VALUES (1);", true));
+
+    std::error_code ec;
+    EXPECT_FALSE(std::filesystem::exists(std::filesystem::path(uri), ec));
+    EXPECT_NO_THROW(main.detach("mem"));
 }
 
 TEST(ConnectionTest, AlwaysCreateRejectsSymlinkTargets) {


### PR DESCRIPTION
Fixes #56

## Problem

A named in-memory URI such as `file:name?mode=memory&cache=shared` was opened as an ordinary disk path: `make_open_flags()` never set `SQLITE_OPEN_URI`, so `sqlite3_open_v2()` treated the whole URI string as a literal filename and silently created a file with that name. Data meant to live only in memory was persisted, and shared named-memory behavior was lost.

## Fix

- `make_open_flags()` now sets `SQLITE_OPEN_URI`. SQLite only applies URI interpretation to names starting with `file:` and clears the flag for every other name, so ordinary filenames behave exactly as before — that split is deliberate and documented in the code.
- `is_special_database()` is replaced by `classify_database_name()`, which mirrors SQLite's own `sqlite3ParseUri()` grammar:
  - authority must be empty or `localhost`
  - `%HH` decoding of the path and of query parameter names/values (`%00` truncates the component, invalid escapes stay literal)
  - `file::memory:` is recognized as an in-memory database
  - `mode=memory` is matched strictly against decoded query parameters (last occurrence wins) instead of by substring, so `?xmode=memory` no longer counts as memory mode
- Path validation (`validate_db_path()`) runs against the decoded URI path (parent directory, symlink, regular-file checks); memory, temporary, and invalid-authority URIs skip disk checks and let SQLite produce its authoritative error.
- The `open_mode` overload uses the decoded path for existence checks and for `always_create` removal.
- `connection.hpp` documents the `file:` URI contract and the ATTACH caveat (SQLite interprets URIs in ATTACH based on the connection's own open flags).

## Tests

Six new/extended `ConnectionTest` cases: named memory URI creates no disk file; shared named memory is visible across two connections and survives until the last one closes; `?xmode=memory` is a real disk database while `mode=bogus` is rejected by SQLite; `mode=%6demory` is decoded; memory URIs need no existing parent directory; `file:` URI paths are validated like plain paths (missing directory/file throw, readonly works); attaching a memory URI creates no disk file.

Suite: 47 tests, all passing on Linux/GCC with bundled SQLite 3.51.2. Also verified manually with the repro from the issue (`disk file exists=0`, clean working directory) and with global URI interpretation enabled via `sqlite3_config(SQLITE_CONFIG_URI, 1)` to mimic a `SQLITE_USE_URI` system build — ordinary filenames stay literal in that mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)